### PR TITLE
Fix json.decoder.JSONDecodeError in extract.py

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -197,7 +197,10 @@ def get_ytplayer_config(html: str) -> Any:
         if function_match:
             logger.debug("finished regex search, matched: %s", pattern)
             yt_player_config = function_match.group(1)
-            return json.loads(yt_player_config)
+            try:
+                return json.loads(yt_player_config)
+            except:
+                pass
 
     raise RegexMatchError(caller="get_ytplayer_config", pattern="config_patterns")
 


### PR DESCRIPTION
A while ago, I started getting `json.decoder.JSONDecodeError`, about some sort of unterminated string in pytubeX's internal JSON loading. As I'm no expert in JSON or anything web, I just made this small change that made sure `get_ytplayer_config` checks *all* the patterns in `config_patterns` for matches before raising an error. This seemed to fix the problem.

Edit: This *may* fix issue #12, not completely sure yet